### PR TITLE
typeddata has been renamed to typed_data

### DIFF
--- a/lib/base32.dart
+++ b/lib/base32.dart
@@ -1,5 +1,5 @@
 library base32;
-import "dart:typeddata";
+import "dart:typed_data";
 class base32 {
 
   /**

--- a/test/base32_test.dart
+++ b/test/base32_test.dart
@@ -1,7 +1,7 @@
 import 'package:unittest/unittest.dart';
 import 'package:base32/base32.dart';
 import 'dart:crypto';
-import 'dart:typeddata';
+import 'dart:typed_data';
 
 void main() {
   group('[Decode]', () {


### PR DESCRIPTION
Do not know how to load 'dart:typeddata''package:base32/base32.dart': Error: line 2 pos 1: library handler failed
import "dart:typeddata";
^
