### PR TITLE
Unittest and crypto should be dev dependencies.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,6 @@ description: Base32 Encoder and Decoder
 homepage: https://github.com/Daegalus/dart-base32
 environment:
   sdk: ">=0.8.10+6 <2.0.0"
-dependencies:
+dev_dependencies:
   unittest: ">=0.9.0 < 0.10.0"
   crypto: ">=0.9.0 < 0.10.0"


### PR DESCRIPTION
The `unittest` and `crypto` packages are only used in tests, so these should be made dev dependencies. This will allow projects depending on base32 to use more recent versions of `unittest` and `crypto` without causing a dependency conflict in pub.