### PR TITLE
Fix: Skip even length check for non-padded encodings (Crockford) and add test for GitHub issue example

### DIFF
--- a/lib/base32.dart
+++ b/lib/base32.dart
@@ -203,7 +203,11 @@ class base32 {
   static bool _isValid(String b32str,
       {Encoding encoding = Encoding.standardRFC4648}) {
     var regex = EncodingUtils.getRegex(encoding);
-    if (b32str.length % 2 != 0 || !regex.hasMatch(b32str)) {
+    // Only check even length for encodings that use padding
+    if (EncodingUtils.getPadded(encoding) && b32str.length % 2 != 0) {
+      return false;
+    }
+    if (!regex.hasMatch(b32str)) {
       return false;
     }
     return true;

--- a/test/base32_test.dart
+++ b/test/base32_test.dart
@@ -54,11 +54,10 @@ void main() {
       expect(decodedString.toString(), equals('48656c6c6f21deadbeef'));
     });
 
-    test('[crockford] 91JPRV3F47FAVFQFF throws FormatException', () {
-      expect(
-          () =>
-              base32.decode('91JPRV3F47FAVFQFF', encoding: Encoding.crockford),
-          throwsA(TypeMatcher<FormatException>()));
+    test('[crockford] 91JPRV3F47FAVFQFF decodes successfully', () {
+      var decoded = base32.decode('91JPRV3F47FAVFQFF', encoding: Encoding.crockford);
+      var decodedString = _hexEncode(decoded);
+      expect(decodedString.toString(), equals('48656c6c6f21deadbeef'));
     });
 
     test('[zbase32] jb1sa5dxr8xk5xzx -> 48656c6c6f21deadbeef', () {
@@ -219,6 +218,14 @@ void main() {
     test('MZXW6YTBOI====== -> foobar', () {
       var decoded = base32.decodeAsString('MZXW6YTBOI======');
       expect(decoded, equals('foobar'));
+    });
+  });
+
+  group('[crockford] encode/decode example from GitHub issue', () {
+    test('colorful-lines', () {
+      final encoded = base32.encodeString('colorful-lines', encoding: Encoding.crockford);
+      final decoded = base32.decodeAsString(encoded, encoding: Encoding.crockford);
+      expect(decoded, equals('colorful-lines'));
     });
   });
 }


### PR DESCRIPTION
- Skip even length check for encodings that do not use padding (e.g., Crockford)
- Add a test for the encode/decode example from the GitHub issue
- All tests pass